### PR TITLE
Remove BrewWorks dependency on BARIS

### DIFF
--- a/GameData/WildBlueIndustries/Pathfinder/Templates/CRP/BrewWorks.txt
+++ b/GameData/WildBlueIndustries/Pathfinder/Templates/CRP/BrewWorks.txt
@@ -211,7 +211,7 @@ PATH_INDUSTRY
 
 	MODULE
 	{
-		name = ModuleBreakableConverter
+		name = ModuleResourceConverter
 		ConverterName = Konkrete
 		StartActionName = Start Konkrete
 		StopActionName = Stop Konkrete

--- a/GameData/WildBlueIndustries/Pathfinder/Templates/ClassicStock/BrewWorks.cfg
+++ b/GameData/WildBlueIndustries/Pathfinder/Templates/ClassicStock/BrewWorks.cfg
@@ -174,7 +174,7 @@ PATH_INDUSTRY
 
 	MODULE
 	{
-		name = ModuleBreakableConverter
+		name = ModuleResourceConverter
 		ConverterName = Konkrete
 		StartActionName = Start Konkrete
 		StopActionName = Stop Konkrete


### PR DESCRIPTION
Fixes https://github.com/Angel-125/Pathfinder/issues/41

Judging by other code in this repo, looks like BARIS dependency is supposed to be removed. Instead of ModuleBreakableConverter in the template, everybody else now gets a ModuleQualityControl in the part itself. Hacienda already has that. So this is no longer needed if I'm understanding it correctly. Every other converter in this file is using ModuleResourceConverter.

Tests: Works for me

Closed the previous https://github.com/Angel-125/Pathfinder/pull/42 to give this fix its own branch.